### PR TITLE
Fix contact section margin reset

### DIFF
--- a/HTML-personalsite/css/styles.css
+++ b/HTML-personalsite/css/styles.css
@@ -117,7 +117,7 @@ p{
 }
 
 .contact-me{
-  margin-left: 0 0 0 0;
+  margin: 0;
   padding: 50px 0 100px 0;
 }
 


### PR DESCRIPTION
## Summary
- correct the `.contact-me` ruleset to use the proper margin shorthand so the section resets its spacing as intended

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cf15697ba08322b3c1d6d8d53e0c09